### PR TITLE
Add support for Django 1.10+

### DIFF
--- a/django_boolean_sum.py
+++ b/django_boolean_sum.py
@@ -1,9 +1,8 @@
 from django.conf import settings
 from django.db.models.aggregates import Sum
-from django.db.models.sql.aggregates import Sum as BaseSQLSum
 
 
-class SQLSum(BaseSQLSum):
+class SQLSum(Sum):
     @property
     def sql_template(self):
         if settings.DATABASES['default']['ENGINE'] == \
@@ -13,8 +12,6 @@ class SQLSum(BaseSQLSum):
 
 
 class BooleanSum(Sum):
-    function = None
-
     def add_to_query(self, query, alias, col, source, is_summary):
         aggregate = SQLSum(col, source=source, is_summary=is_summary,
                            **self.extra)


### PR DESCRIPTION
Should fix #3. At least in my pet project I no longer get warnings in 1.9 and limited tests are passing :) @akolpakov please give it a try my friend and tell us if it works.

Things to do:
- Update readme